### PR TITLE
feat: generate page components for all md files

### DIFF
--- a/src/blueprints/docs/data.js
+++ b/src/blueprints/docs/data.js
@@ -1,6 +1,7 @@
 import path from 'path'
 import graymatter from 'gray-matter'
 import defu from 'defu'
+import { createRoutes } from '@nuxt/utils'
 import { walk, join, exists, readFile, routePath, escapeChars } from '../../utils'
 import PromisePool from '../../pool'
 import { indexKeys, defaultMetaSettings, maxSidebarDepth } from './constants'
@@ -73,6 +74,13 @@ export default async function ({ options: { docs: docOptions } }) {
     return path.endsWith('.md')
   })
 
+  const routesConfig = {
+    files: jobs.map(f => `/${f}`),
+    srcDir: this.options.srcDir,
+    supportedExtensions: ['md']
+  }
+  const routes = createRoutes(routesConfig)
+
   const sources = {}
   const $pages = {}
 
@@ -120,6 +128,7 @@ export default async function ({ options: { docs: docOptions } }) {
   })
 
   return {
+    routes,
     options,
     sources
   }


### PR DESCRIPTION
This is a proof of concept for a possible different approach then using the current wildcard page component which separately loads json files. (Note: Its quickly hacked into existing code for `docs` mode (due to hardcoded layout) and not nice / optimised at all)

It uses nuxt's `createRoutes` method to generate routes for all `.md` files in the srcDir and then creates corresponding page components for all the routes using a simple page component template. 

_Why is this ok to do?_

Normally when you want to use different languages in your vue files you need to add a webpack loader or custom-block for vue loader which adds support for that language. But a webpack loader simply returns a new string of source code that can be parsed by a different loader until we have pure js. So if we would add a webpack loader that understands markdown in vue files, we would need to do exactly the same as we do now but just on the webpack layer instead of the nuxt layer.