### PR TITLE
refactor(blog): pass meta to source.title for better customization

### DIFF
--- a/packages/blog/src/blueprint/data.js
+++ b/packages/blog/src/blueprint/data.js
@@ -38,7 +38,7 @@ export async function _parseEntry ({ root, prefix = '', path: sourcePath }, mdPr
     }
 
     source.id = this.config.source.id(source)
-    source.path = `${this.config.prefix}${normalizePath(slug || this.config.source.path(fileName, source))}`
+    source.path = `${this.config.prefix}${normalizePath(this.config.source.path(fileName, source, meta))}`
 
     return source
   } catch (error) {

--- a/packages/blog/src/blueprint/source.js
+++ b/packages/blog/src/blueprint/source.js
@@ -45,7 +45,11 @@ const source = {
 
   // path() determines the final URL path of a Markdown source
   // In `blog` mode, the default format is /YYYY/MM/DD/<slug>
-  path (fileName, { title, published }) {
+  path (fileName, { title, published, meta = {} }) {
+    if (meta.slug) {
+      return meta.slug
+    }
+
     const slug = slugify(title || fileName)
     const date = published.toString().split(/\s+/).slice(1, 4).reverse()
     return `${date[0]}/${date[2].toLowerCase()}/${date[1]}/${slug}/`

--- a/packages/blog/test/unit/source.test.js
+++ b/packages/blog/test/unit/source.test.js
@@ -48,6 +48,18 @@ describe('source.path', () => {
     expect(source.path('post', data))
       .toEqual('2019/jun/01/post/')
   })
+
+  test('with meta.slug', () => {
+    const data = {
+      published: new Date(Date.parse('June 01, 2019')),
+      meta: {
+        slug: 'xyz/my/big/post'
+      }
+    }
+
+    expect(source.path('post', data))
+      .toEqual('xyz/my/big/post')
+  })
 })
 
 describe('source.title', () => {


### PR DESCRIPTION
This enables greater path customization power.