### PR TITLE
fix postcss config

### DIFF
--- a/packages/core/src/blueprint/index.js
+++ b/packages/core/src/blueprint/index.js
@@ -159,7 +159,9 @@ export default class PressBlueprint extends Blueprint {
     this.rootConfig.isGenerating = this.nuxt.options._generate || this.nuxt.options.target === 'static'
 
     // Enable all of https://preset-env.cssdb.org/features
-    this.nuxt.options.build.postcss.preset.stage = 0
+    if (typeof this.nuxt.options.build.postcss === "object") {
+      this.nuxt.options.build.postcss.preset.stage = 0
+    }
 
     // Hable is used in plugin middleware but needs to be transpiled
     this.nuxt.options.build.transpile = this.nuxt.options.build.transpile || []


### PR DESCRIPTION
[nuxt docs](https://nuxtjs.org/api/configuration-build#postcss) says that `build.postcss` option can be Boolean and Function

I have added condition to check if it's possible to override the `postcss` option.
Now it will not fail build if user sets `postcss` to false.


Also, I want to ask, maybe `nuxt/press` shouldn't set `stage` to 0? I think this setting is out of scope of `nuxt/press` module and the user should decide what `stage` to use.