### PR TITLE
fix: install beta

### DIFF
--- a/distributions/nuxt-press/package.json
+++ b/distributions/nuxt-press/package.json
@@ -14,7 +14,6 @@
     }
   ],
   "files": [
-    "bin",
     "src",
     "postinstall.js"
   ],

--- a/distributions/nuxt-press/package.json
+++ b/distributions/nuxt-press/package.json
@@ -5,9 +5,6 @@
   "main": "src/index.js",
   "repository": "https://github.com/nuxt/press",
   "license": "MIT",
-  "bin": {
-    "nuxt-press": "./bin/cli.js"
-  },
   "contributors": [
     {
       "name": "Jonas Galvez (@galvez)"


### PR DESCRIPTION
`npm install @nuxt/press@beta` throws ENOENT: no such file or directory, 
chmod '/Users/front/work/minter-network/node_modules/@nuxt/press/bin/cli.js'

This PR should fix it
