### PR TITLE
fix stopObserver

### DIFF
--- a/packages/docs/src/blueprint/components/topic.vue
+++ b/packages/docs/src/blueprint/components/topic.vue
@@ -82,7 +82,7 @@ export default {
       this.startObserver()
     },
     stopObserver() {
-      if (!this._observer) {
+      if (this._observer) {
         this._observer.disconnect()
         this._observer = undefined
       }


### PR DESCRIPTION
Looks like there was a typo.
Checking for a falsy `_observer` has no sense because then we will not be able to call `.disconnect()` on it, if it is falsy.

So I have changed condition to check truthy `_observer`